### PR TITLE
fix: improved scaling

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -64,7 +64,7 @@
 		</div>
 		<div id="ToggleOverlayButton">🖼️</div>
 		<div id="OverlayCanvasOutput">
-			<canvas willReadFrequently="true" width="1000" height="1000"></canvas>
+			<canvas willReadFrequently="true" width="4000" height="4000"></canvas>
 			<canvas id="canvas" width="27" height="27"></canvas>
 		</div>
 		<script src="./main.js" defer></script>

--- a/dist/main.js
+++ b/dist/main.js
@@ -855,8 +855,8 @@ ___CSS_LOADER_EXPORT___.push([module.id, `body {
   --scale: 100;
   --totalitems: 37;
   width: 100%;
-  max-width: calc((var(--maxcount) * 72px) * clamp(1, (var(--scale) / 100), (var(--scale) / 100)));
-  min-height: calc((((var(--totalitems) / var(--maxcount)) + 1) * (27px * (var(--scale) / 100))) * clamp(1, (var(--scale) / 100), (var(--scale) / 100)));
+  max-width: calc((var(--maxcount) * 72px));
+  min-height: calc((((var(--totalitems) / var(--maxcount)) + 1) * 27px));
   display: grid;
   justify-content: flex-start;
   align-items: flex-start;
@@ -864,10 +864,10 @@ ___CSS_LOADER_EXPORT___.push([module.id, `body {
   margin:0 auto;
   padding:0;
   gap: 2px;
-  transform: scale(calc(var(--scale) / 100));
-  transform-origin: top;
-  grid-template-columns: repeat(var(--maxcount), calc(30px * clamp(1, (var(--scale) / 100) / 2, 2)));
-  grid-template-rows: repeat(8, calc(30px * clamp(1, (var(--scale) / 100) / 2, 2)));
+  /* transform: scale(calc(var(--scale) / 100)); */
+  /* transform-origin: top; */
+  grid-template-columns: repeat(var(--maxcount),30px);
+  grid-template-rows: repeat(8, 30px);
   position: relative;
 }
 
@@ -18953,7 +18953,7 @@ function paintCanvas(canvas) {
         .querySelector('canvas')
         .getContext('2d', { willReadFrequently: true });
     overlayCanvasContext.clearRect(0, 0, overlayCanvasContext.canvas.width, overlayCanvasContext.canvas.height);
-    overlayCanvasContext.drawImage(canvas, 0, 0);
+    overlayCanvasContext.drawImage(canvas, 0, 0, _a1sauce__WEBPACK_IMPORTED_MODULE_0__.getSetting('uiScale') * 4, (_a1sauce__WEBPACK_IMPORTED_MODULE_0__.getSetting('uiScale') * 4 * canvas.height) / canvas.width);
     var overlay = overlayCanvasOutput.querySelector('canvas');
     _a1sauce__WEBPACK_IMPORTED_MODULE_0__.updateSetting('overlayImage', overlay.toDataURL());
     _a1sauce__WEBPACK_IMPORTED_MODULE_0__.updateSetting('firstFrame', true);

--- a/src/css/betterbuffsbar.css
+++ b/src/css/betterbuffsbar.css
@@ -53,8 +53,8 @@ body {
   --scale: 100;
   --totalitems: 37;
   width: 100%;
-  max-width: calc((var(--maxcount) * 72px) * clamp(1, (var(--scale) / 100), (var(--scale) / 100)));
-  min-height: calc((((var(--totalitems) / var(--maxcount)) + 1) * (27px * (var(--scale) / 100))) * clamp(1, (var(--scale) / 100), (var(--scale) / 100)));
+  max-width: calc((var(--maxcount) * 72px));
+  min-height: calc((((var(--totalitems) / var(--maxcount)) + 1) * 27px));
   display: grid;
   justify-content: flex-start;
   align-items: flex-start;
@@ -62,10 +62,10 @@ body {
   margin:0 auto;
   padding:0;
   gap: 2px;
-  transform: scale(calc(var(--scale) / 100));
-  transform-origin: top;
-  grid-template-columns: repeat(var(--maxcount), calc(30px * clamp(1, (var(--scale) / 100) / 2, 2)));
-  grid-template-rows: repeat(8, calc(30px * clamp(1, (var(--scale) / 100) / 2, 2)));
+  /* transform: scale(calc(var(--scale) / 100)); */
+  /* transform-origin: top; */
+  grid-template-columns: repeat(var(--maxcount),30px);
+  grid-template-rows: repeat(8, 30px);
   position: relative;
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -64,7 +64,7 @@
 		</div>
 		<div id="ToggleOverlayButton">🖼️</div>
 		<div id="OverlayCanvasOutput">
-			<canvas willReadFrequently="true" width="1000" height="1000"></canvas>
+			<canvas willReadFrequently="true" width="4000" height="4000"></canvas>
 			<canvas id="canvas" width="27" height="27"></canvas>
 		</div>
 		<script src="./main.js" defer></script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,7 +243,13 @@ function paintCanvas(canvas: HTMLCanvasElement) {
 		overlayCanvasContext.canvas.width,
 		overlayCanvasContext.canvas.height
 	);
-	overlayCanvasContext.drawImage(canvas, 0, 0);
+	overlayCanvasContext.drawImage(
+		canvas,
+		0,
+		0,
+		sauce.getSetting('uiScale') * 4,
+		(sauce.getSetting('uiScale') * 4 * canvas.height) / canvas.width
+	);
 	let overlay = overlayCanvasOutput.querySelector('canvas');
 	sauce.updateSetting('overlayImage', overlay.toDataURL());
 	sauce.updateSetting('firstFrame', true);


### PR DESCRIPTION
Resize the canvas image depending on scale factor instead of transform: scale() the UI. This allows buffs to be modified when scaled and generally cleans up scaling nicely.

It can still get cut off on the right side - if that happens make the Alt1 app window wider before minimizing. If you go to wide for some reason the canvas... shrinks? Not sure why. But this is better than things were at least.