### PR TITLE
Various minor cleanups and add Webpack automation

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -4,18 +4,22 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
+    name: Webpack Build
     runs-on: ubuntu-latest
-    container:
-      image: node:lts
-    env:
-      NODE_ENV: production
     steps:
       - uses: actions/checkout@v3
-      - run: |
-          npm install
-          npm run build
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm install
+      - run: npm run build
+        env:
+          NODE_ENV: production
       - run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -1,0 +1,24 @@
+name: Webpack
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node:lts
+    env:
+      NODE_ENV: production
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          npm install
+          npm run build
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add dist
+          git commit -m "[skip ci] updating distribution"
+          git push

--- a/package.json
+++ b/package.json
@@ -6,8 +6,6 @@
 	"dependencies": {
 		"alt1": "0.0.6",
 		"html-to-image": "^1.11.11",
-		"html2canvas": "^1.4.1",
-		"latest": "^0.2.0",
 		"sortablejs": "^1.15.0"
 	},
 	"devDependencies": {

--- a/src/a1sauce.ts
+++ b/src/a1sauce.ts
@@ -483,3 +483,9 @@ export function updateSetting(setting, value) {
 	save_data[setting] = value;
 	localStorage.setItem(config.appName, JSON.stringify(save_data));
 }
+
+export async function timeout(millis: number) {
+	return new Promise(function (resolve) {
+		setTimeout(resolve, millis)
+	});
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -303,7 +303,6 @@ let checkForCombat = true;
 let updatingOverlayPosition = false;
 let timeUntilHide = 2;
 let checkCombatState = () => {
-
 	if (updatingOverlayPosition) {
 		inCombat = true;
 		return;
@@ -869,7 +868,7 @@ async function noDetection(maxAttempts: number, interval: any, bar: string) {
 		return;
 	}
 	if (maxAttempts < 10) {
-		setTimeout(() => {}, 1000 * maxAttempts ** 2);
+		await sauce.timeout(1000 * maxAttempts ** 2);
 		maxAttempts++;
 	}
 	console.log(
@@ -879,9 +878,8 @@ async function noDetection(maxAttempts: number, interval: any, bar: string) {
 
 async function showTooltip(msg: string, duration: number) {
 	alt1.setTooltip(msg);
-	await new Promise((done) => setTimeout(done, duration));
+	await sauce.timeout(duration);
 	alt1.clearTooltip();
-	return;
 }
 
 /*
@@ -1013,14 +1011,14 @@ async function findStatus(
 
 				// Pause the check for a tick since we don't need to rapidly update
 				//a buff that won't have a more precise value for 1 minute
-				await new Promise((done) => setTimeout(done, 600));
+				await sauce.timeout(600);
 			}
 			// If we've reached 11 seconds force the item active for 10s and then set it to inactive
 			else if (expirationPulse && timearg.time == 11 && !onCooldown) {
 				element.dataset.time = '<10s';
 				await setActive(element);
 				// This can be desynced from in-game 10s but it's accurate enough
-				await new Promise((done) => setTimeout(done, 10000));
+				await sauce.timeout(10000);
 				await setInactive(element);
 				if (sauce.getSetting('showTooltipReminders')) {
 					showTooltip('Overload expired', 3000);
@@ -1071,12 +1069,12 @@ async function findStatus(
 	if (timearg == undefined && foundBuff && !showCooldown) {
 		// The FoundBuff ensures we don't wait 10s to add inactive when BBB first loads
 		if (expirationPulse) {
-			await new Promise((done) => setTimeout(done, 10000));
+			await sauce.timeout(10000);
 		}
 		await setInactive(element);
 	}
 	// Give a very brief pause before checking again
-	await new Promise((done) => setTimeout(done, 10));
+	await sauce.timeout(10);
 	return timearg;
 }
 
@@ -1147,12 +1145,13 @@ async function findDeathspores(
 	if (timearg == undefined && foundBuff && !showCooldown) {
 		// The FoundBuff ensures we don't wait 10s to add inactive when BBB first loads
 		if (expirationPulse) {
-			await new Promise((done) => setTimeout(done, 10000));
+			await sauce.timeout(10000);
+
 		}
 		await setInactive(element);
 	}
 	// Give a very brief pause before checking again
-	await new Promise((done) => setTimeout(done, 10));
+	await sauce.timeout(10);
 	return timearg;
 }
 
@@ -1161,7 +1160,7 @@ async function startCooldownTimer(element: HTMLElement, cooldownTimer: number) {
 	 * Wait the final 1s then set buff to 'cooldown' state
 	 * After its cooldown has finished set it back to 'inactive' state (actually 'readyToBeUsed')
 	 */
-	await new Promise((done) => setTimeout(done, 1050));
+	await sauce.timeout(1050);
 	await setCooldown(element, cooldownTimer);
 	if (element.dataset.cooldown != '0' && element.dataset.startedTimer !== 'true') {
 		element.dataset.startedTimer = 'true';
@@ -1582,7 +1581,7 @@ async function setCooldown(element: HTMLElement, cooldownTimer: number) {
 	element.dataset.time = '';
 	element.dataset.startedTimer = 'false';
 	element.dataset.cooldown = cooldownTimer.toString();
-	await new Promise((done) => setTimeout(done, 2000));
+	return sauce.timeout(2000);
 }
 
 async function setInactive(element: HTMLElement) {
@@ -1666,13 +1665,13 @@ async function findBolgStacks(buffs: BuffReader.Buff[]) {
 				let bolgStacks = bolgData[1];
 				buffsList.BolgStacksBuff.dataset.time = bolgStacks;
 				buffsList.BalanceByForceBuff.dataset.time = bolgTime;
-				await new Promise((done) => setTimeout(done, 600));
+				await sauce.timeout(600);
 			}
 		}
 		if (bolgStacksData == undefined) {
 			buffsList.BolgStacksBuff.classList.add('inactive');
 			buffsList.BalanceByForceBuff.classList.add('inactive');
-			await new Promise((done) => setTimeout(done, 600));
+			await sauce.timeout(600);
 			buffsList.BolgStacksBuff.dataset.time = '';
 			buffsList.BalanceByForceBuff.dataset.time = '';
 		} else {
@@ -1680,7 +1679,7 @@ async function findBolgStacks(buffs: BuffReader.Buff[]) {
 			buffsList.BalanceByForceBuff.classList.remove('inactive');
 		}
 	}
-	await new Promise((done) => setTimeout(done, 10));
+	await sauce.timeout(10);
 	return bolgStacksData;
 }
 
@@ -1700,7 +1699,7 @@ async function parseBolgBuff(data: string) {
 			bolgSpecActive = true;
 			bolgSpecTime = '30';
 			bolgStacks = results[0].groups.stacks;
-			await new Promise((done) => setTimeout(done, 30000));
+			await sauce.timeout(30000);
 			bolgSpecActive = false;
 		} else if (bolgSpecActive) {
 			bolgSpecTime = results[0].groups.time ?? 0;
@@ -1710,12 +1709,7 @@ async function parseBolgBuff(data: string) {
 				bolgSpecTime = results[0].groups.time;
 				bolgStacks = '0';
 				bolgSpecActive = true;
-				await new Promise((done) =>
-					setTimeout(
-						done,
-						parseInt(results[0].groups.time, 10) * 1000
-					)
-				);
+				await sauce.timeout(parseInt(results[0].groups.time, 10) * 1000);
 				bolgSpecActive = false;
 			} else {
 				bolgSpecTime = '';
@@ -1753,10 +1747,9 @@ async function setOverlayPosition() {
 		});
 		currentOverlayPosition = sauce.getSetting('overlayPosition');
 		alt1.overLayRefreshGroup('group1');
-		await new Promise((done) => setTimeout(done, 200));
+		await sauce.timeout(200);
 	}
 	alt1.clearTooltip();
-	return;
 }
 
 async function setOverlayPosition2() {
@@ -1783,10 +1776,9 @@ async function setOverlayPosition2() {
 		});
 		currentOverlay2Position = sauce.getSetting('overlay2Position');
 		alt1.overLayRefreshGroup('group2');
-		await new Promise((done) => setTimeout(done, 200));
+		await sauce.timeout(200);
 	}
 	alt1.clearTooltip();
-	return;
 }
 
 async function setOverlayPosition3() {
@@ -1813,10 +1805,9 @@ async function setOverlayPosition3() {
 		});
 		currentOverlay3Position = sauce.getSetting('overlay3Position');
 		alt1.overLayRefreshGroup('group3');
-		await new Promise((done) => setTimeout(done, 200));
+		await sauce.timeout(200);
 	}
 	alt1.clearTooltip();
-	return;
 }
 
 function updateLocation(e) {
@@ -1877,7 +1868,7 @@ async function startOverlay(element: HTMLElement, region?: string) {
 	let buffsPerRow = sauce.getSetting('buffsPerrow');
 	let refreshRate = parseInt(sauce.getSetting('overlayRefreshRate'), 10);
 	let overlayPosition;
-	await new Promise((done) => setTimeout(done, 1000));
+	await sauce.timeout(1000);
 	while (true) {
 		let uiScale = sauce.getSetting('uiScale' + region);
 		if (region == '') {
@@ -1887,44 +1878,43 @@ async function startOverlay(element: HTMLElement, region?: string) {
 		} else if (region == '3') {
 			overlayPosition = currentOverlay3Position;
 		}
-		htmlToImage
-			.toCanvas(overlay, {
+		try {
+			let dataUrl = await htmlToImage.toCanvas(overlay, {
 				backgroundColor: 'transparent',
 				width: parseInt(styles.minWidth, 10),
 				height:
 					parseInt(styles.minHeight, 10) +
 					Math.floor(totalTrackeDItems / buffsPerRow + 1) *
-						27 *
-						(uiScale / 100),
+					27 *
+					(uiScale / 100),
 				quality: 1,
 				pixelRatio: uiScale / 100 - 0.00999999999999999999,
 				skipAutoScale: true,
-			})
-			.then((dataUrl) => {
-				if (inCombat || element == getByID('Buffs')) {
-					let base64ImageString = dataUrl
-						.getContext('2d')
-						.getImageData(0, 0, dataUrl.width, dataUrl.height);
-					alt1.overLaySetGroup('region' + region);
-					alt1.overLayFreezeGroup('region' + region);
-					alt1.overLayClearGroup('region' + region);
-					alt1.overLayImage(
-						overlayPosition.x,
-						overlayPosition.y,
-						a1lib.encodeImageString(base64ImageString),
-						base64ImageString.width,
-						refreshRate
-					);
-					alt1.overLayRefreshGroup('region' + region);
-				} else {
-					alt1.overLayClearGroup('region' + region);
-					alt1.overLayRefreshGroup('region' + region);
-				}
-			})
-			.catch((e) => {
-				console.error(`html-to-image failed to capture`, e);
 			});
-		await new Promise((done) => setTimeout(done, refreshRate));
+
+			if (inCombat || element == getByID('Buffs')) {
+				let base64ImageString = dataUrl
+					.getContext('2d')
+					.getImageData(0, 0, dataUrl.width, dataUrl.height);
+				alt1.overLaySetGroup('region' + region);
+				alt1.overLayFreezeGroup('region' + region);
+				alt1.overLayClearGroup('region' + region);
+				alt1.overLayImage(
+					overlayPosition.x,
+					overlayPosition.y,
+					a1lib.encodeImageString(base64ImageString),
+					base64ImageString.width,
+					refreshRate
+				);
+				alt1.overLayRefreshGroup('region' + region);
+			} else {
+				alt1.overLayClearGroup('region' + region);
+				alt1.overLayRefreshGroup('region' + region);
+			}
+		} catch (e) {
+			console.error(`html-to-image failed to capture`, e);
+		}
+		await sauce.timeout(refreshRate);
 	}
 }
 
@@ -2017,9 +2007,7 @@ function loadSettings() {
 		'blink-maintainables',
 		sauce.getSetting('showMaintainableBlinking')
 	);
-	if (
-		parseInt(settingsObject.UIScale.querySelector('input').value, 10) < 100
-	) {
+	if (parseInt(settingsObject.UIScale.querySelector('input').value, 10) < 100) {
 		helperItems.TrackedBuffs.classList.add('scaled');
 	}
 
@@ -2507,9 +2495,7 @@ settingsObject.BlinkExpiredBuffs.addEventListener('change', () => {
 
 settingsObject.UIScale.addEventListener('change', () => {
 	getByID('Buffs').style.setProperty('--scale', sauce.getSetting('uiScale'));
-	if (
-		parseInt(settingsObject.UIScale.querySelector('input').value, 10) < 100
-	) {
+	if (parseInt(settingsObject.UIScale.querySelector('input').value, 10) < 100) {
 		helperItems.TrackedBuffs.classList.add('scaled');
 	}
 });
@@ -2525,22 +2511,6 @@ settingsObject.ProfileManager.querySelector('.profile-list').addEventListener(
 	}
 );
 
-settingsObject.ProfileManager.querySelector('.load-btn').addEventListener(
-	'click',
-	() => {
-		setTimeout(function () {}, 100);
-		location.reload();
-	}
-);
-
-settingsObject.OverlayActive.querySelector('input').addEventListener(
-	'click',
-	() => {
-		setTimeout(function () {}, 100);
-		location.reload();
-	}
-);
-
 settingsObject.Brightness.querySelector('input').addEventListener('change', (e) => {
 	document.documentElement.style.setProperty(
 		'--brightness',
@@ -2548,15 +2518,19 @@ settingsObject.Brightness.querySelector('input').addEventListener('change', (e) 
 	);
 });
 
-settingsObject.debugMode
-	.querySelector('input')
-	.addEventListener('change', () => {
-		setTimeout(function () {}, 100);
-		location.reload();
-	});
+settingsObject.ProfileManager.querySelector('.load-btn').addEventListener('click', () => {
+	location.reload();
+});
+
+settingsObject.OverlayActive.querySelector('input').addEventListener('click', () => {
+	location.reload();
+});
+
+settingsObject.debugMode.querySelector('input').addEventListener('change', () => {
+	location.reload();
+});
 
 settingsObject.beta.querySelector('input').addEventListener('change', () => {
-	setTimeout(function () {}, 100);
 	location.reload();
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,7 @@ var buffImages = a1lib.webpackImages({
 	prayerRenewActive: require('./asset/data/Prayer_Renew_Active-noborder.data.png'),
 	superAntifireActive: require('./asset/data/Super_Anti-Fire_Active-noborder.data.png'),
 	supremeOverloadActive: require('./asset/data/Supreme_Overload_Potion_Active-noborder.data.png'),
-	timeRift: require('./asset/data/Time_Rift-noborder.data.png'),
+	timeRift: require('./asset/data/Time_rift-noborder.data.png'),
 	aura: require('./asset/data/Aura-noborder.data.png'),
 	bonfireBoost: require('./asset/data/Bonfire_Boost-noborder.data.png'),
 	grimoire: require("./asset/data/Erethdor's_grimoire-noborder.data.png"),
@@ -171,7 +171,7 @@ var buffImages = a1lib.webpackImages({
 	Antifire: require('./asset/data/antifire_top.data.png'),
 	PrayerRenewal: require('./asset/data/Prayer_Renew_Active-noborder.data.png'),
 	DeathSpark: require('./asset/data/Death_Spark.data.png'),
-	ThreadsOfFate: require('./asset/data/Threads_Of_Fate.data.png'),
+	ThreadsOfFate: require('./asset/data/Threads_of_Fate.data.png'),
 	ConjureSkeleton: require('./asset/data/skeleton_warrior-top.data.png'),
 	ConjureZombie: require('./asset/data/putrid_zombie-top.data.png'),
 	ConjureGhost: require('./asset/data/vengeful_ghost-top.data.png'),
@@ -260,7 +260,7 @@ var quiverImages = a1lib.webpackImages({
 var enemyImages = a1lib.webpackImages({
 	DeathMark: require('./asset/data/Death_Mark.data.png'),
 	Vulnerability: require('./asset/data/Vulnerability_bordered.data.png'),
-	Bloat: require('./asset/data/bloated.data.png'),
+	Bloat: require('./asset/data/Bloated.data.png'),
 });
 
 export function startBetterBuffsBar() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
 		library: { type: 'umd', name: 'NyusNecroJobGauge' },
 	},
 	devtool: false,
-	mode: 'development',
+	mode: process.env.NODE_ENV || 'development',
 	// prevent webpack from bundling these imports (alt1 libs can use them when running in nodejs)
 	externals: ['sharp', 'canvas', 'electron/common'],
 	resolve: {


### PR DESCRIPTION
This PR comes with a bunch of stuff:

* Removes two dependencies which are no longer used (afaict).
* Fixes the names of 3 resources to match the correct case.
* Removes some unnecessary timeouts, and adds a `sauce.timeout` convenience function.
* Correctly waits for `htmlToImage.toCanvas` to conclude before re-trying.
* Allows Webpack to use `NODE_ENV` rather than hardcoded to `development`.
* Adds a GitHub Action to automatically build and push `dist`, only on commits into `main`.

Feel free to reject any of the above, kinda just did them for fun :)

I stopped short of some more involved changes, specifically around overlay positioning, but I might follow up with those later (in a different PR).